### PR TITLE
error in line 511, .post-content blockquote.small

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -508,7 +508,7 @@ figcaption {
 }
 
 .post-content blockquote.small {
-/ / display: flex;
+    display: flex;
     position: relative;
     flex-direction: column;
     border: 2px solid rgba(152, 152, 152, 0.15);


### PR DESCRIPTION
There are two "/" separated by spaces that I believe are errors.  I deleted them and everything seems to work fine, but also wonder if they were meant to be a /* ... */ to comment out the display: flex.